### PR TITLE
(maint) update dependecy and refactor documentantion

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,48 +2,73 @@
 
 #### Table of Contents
 
-1. [Description](#description)
-2. [Setup - The basics of getting started with ca_extend](#setup)
-3. [Usage - Configuration options and additional functionality](#usage)
+1. [Overview](#overview)
+1. [Description - What the module does and why it is useful](#description)
+1. [Setup - The basics of getting started with this module](#setup)
+1. [Usage - Configuration options and additional functionality](#usage)
+1. [Reference - An under-the-hood peek at what the module is doing](#reference)
+1. [Development - Guide for contributing to the module](#development)
+
+## Overview
+
+This module can extend a certificate authority (CA) that's about to expire or has already expired.
+
+A Puppet CA certificate is only valid for a finite time (usually five years), after which it expires.
+When a CA certificate expires, Puppet services will no longer accept any certificates signed by that CA, and your Puppet infrastructure will immediately stop working.
+
+If your CA certificate is expiring soon (or it's already expired), you need to:
+
+* Generate a new CA certificate using the existing CA keypair.
+* Distribute the new CA certificate to agents.
+
+This module can automate those tasks.
 
 ## Description
 
-A set of Plans and Tasks to extend the expiration date of the certificate for the certificate authority in Puppet Enterprise and open source Puppet and distribute the certificate to agent nodes.
+This module is composed of Plans and Tasks to extend the expiration date of the CA certificate in Puppet Enterprise (and Puppet Open Source) and distribute that CA certificate to agents.
 
-Note that in open source Puppet, if the CA cert is only used by the Puppet CA and no other integrations, there is no further action to take after using the two main plans.  However, if it is used for other purposes such as SSL encrypted PuppetDB traffic, then these integrations will need to have their copy of the cert updated.  If it is stored in any keystores, these will also need to be updated.
+Note that, with Puppet Open Source, if the CA certificate is only used by the Puppet CA and no other integrations, there is no further action to take after using the two Plans.
+However, if it is used for other integrations (such as SSL encrypted PuppetDB traffic) then those integrations will need to have their copy of the CA certificate updated. 
+If the CA certificate is stored in any keystores, those will also need to be updated.
 
-The functionality of this module is divided into two main plans:
+The functionality of this module is composed into two Plans:
 
 *  `ca_extend::extend_ca_cert`
-    * Extends the CA certificate and configures the master and any compile masters to use the new certificate
+    * Extend the CA certificate and configure the Master and any Compilers to use that extended certificate.
 *  `ca_extend::upload_ca_cert`
-    * Distributes the certificate to any number of agents.  Any protocol supported by Bolt can be used, such as `ssh`, `winrm`, or `PCP`.
+    * Distribute the CA certificate to agents using any transport supported by Puppet Bolt, such as `ssh`, `winrm`, or `pcp`.
 
-Regardless of whether the CA cert has passed expiration or not, the `extend_ca_cert` plan may be used to extend its expiration date in-place and configure the master and compilers to use it.
+Regardless of whether the CA certificate is expired, the `extend_ca_cert` plan may be used to extend its expiration date in-place and configure the Master and any Compilers to use it.
 
-After the CA is functional again (or if it had yet to expire), there are two options for distributing the new cert to agents.
+After the CA certificate has been extended, there are two methods for distributing it to agents.
 
-* Using the `ca_extend::upload_ca_cert` plan or another method to copy the new `ca.pem` into place on agents.
-* Deleting `ca.pem` from agents and letting them download the file as part of the next Puppet agent run.  The agent will re-download this file only if it is absent, so it must be deleted to get a new copy using this method.
+* Using the `ca_extend::upload_ca_cert` plan or another method to copy the CA certificate to agents.
+* Manually deleting `ca.pem` on agents and letting them download that file as part of the next Puppet agent run. The agent will download that file only if it is absent, so it must be deleted to use this method.
 
-There are also two complementary tasks to check the expiry of the CA cert and any agent certificates.
+There are also two complementary tasks to check the expiration date of the CA certificate or any agent certificates.
 
-* `ca_extend::check_agent_expiry`
-    * Checks if any agent certificates expire by a certain date.  Defaults to 3 months from today
 * `ca_extend::check_ca_expiry`
-    * Checks if the CA certificate expires by a certain date.  Defaults to 3 months from today
+    * Checks if the CA certificate expires by a certain date. Defaults to three months from today.
+* `ca_extend::check_agent_expiry`
+    * Checks if any agent certificate expires by a certain date. Defaults to three months from today.
+    
+** If the CA certificate is expiring or expired, you must extend it as soon as possible. **
 
 ## Setup
-This module requires a [Bolt installation](https://puppet.com/docs/bolt/latest/bolt_installing.html) >= 1.21.0 on either a client machine or the Puppet master
 
-The recommended installation procedure for this module is to use a [Bolt Puppetfile](https://puppet.com/docs/bolt/latest/installing_tasks_from_the_forge.html#task-8928).  From within a [Boltdir](https://puppet.com/docs/bolt/latest/bolt_project_directories.html#embedded-project-directory), specify this module and `puppetlabs-stdlib` as dependencies and run `bolt puppetfile install`.  For example, to install Bolt and the required modules on an EL 7 master:
+This module requires [Puppet Bolt](https://puppet.com/docs/bolt/latest/bolt_installing.html) >= 1.21.0 on either on the Master or an agent.
 
-```
+The recommended procedure for installation this module is to use a [Bolt Puppetfile](https://puppet.com/docs/bolt/latest/installing_tasks_from_the_forge.html#task-8928).
+From within a [Boltdir](https://puppet.com/docs/bolt/latest/bolt_project_directories.html#embedded-project-directory), specify this module and `puppetlabs-stdlib` as dependencies and run `bolt puppetfile install`.
+
+For example, to install Bolt and the required modules on a Master running EL 7:
+
+```bash
 sudo rpm -Uvh https://yum.puppet.com/puppet-tools-release-el-7.noarch.rpm
 sudo yum install puppet-bolt
 ```
 
-```
+```bash
 mkdir -p ~/Boltdir
 cd !$
 
@@ -56,37 +81,83 @@ EOF
 bolt puppetfile install
 ```
 
-## Dependencies
+### Dependencies
 
-*  A [Bolt installation](https://puppet.com/docs/bolt/latest/bolt_installing.html) >= 1.21.0
-*  [puppetlabs-stdlib](https://puppet.com/docs/bolt/latest/bolt_installing.html) >= 3.2.0 < 6.0.0
-*  A `base64` binary on the master which supports the `-w` flag
+*  A [Puppet Bolt](https://puppet.com/docs/bolt/latest/bolt_installing.html) >= 1.21.0
+*  [puppetlabs-stdlib](https://puppet.com/docs/bolt/latest/bolt_installing.html)
+*  A `base64` binary on the Master which supports the `-w` flag
 *  `bash` >= 4.0 on the master
 
-## Configuration
+### Configuration
 
-### Inventory
+#### Inventory
 
-This module works best with a Bolt [inventory file](https://puppet.com/docs/bolt/latest/inventory_file.html) to support simultaneous uploads to \*nix and Windows agents.  See the Bolt documentation for how to configure the inventory.  See the `REFERENCE.md` for a sample inventory file.
+This module works best with a Bolt [inventory file](https://puppet.com/docs/bolt/latest/inventory_file.html) to allow for simultaneous uploads to \*nix and Windows agents.
+See the Bolt documentation for how to configure an inventory file.
+See the `REFERENCE.md` for a sample inventory file.
 
-Alternatively, one can use an `ssh` config file if only using this protocol to connect to agents.  Bolt defaults to using `ssh`, which in turn will use `~/.ssh/config` for options such as the username and identity file.
+Alternatively, you can use an `ssh` config file if you will only use that transport to upload the CA certificate to agents.
+Bolt defaults to using the `ssh` transport, which in turn will use `~/.ssh/config` for options such as `username` and `private-key`.
 
-### Connecting to PuppetDB
+#### PuppetDB
 
-Another convenient way to specify targets for the `ca_extend::upload_ca_cert` plan is by connecting Bolt to [PuppetDB](https://puppet.com/docs/bolt/latest/bolt_connect_puppetdb.html), after which the [--query](https://puppet.com/docs/bolt/latest/bolt_command_reference.html#command-options) can be used to specify a node list. See `REFERENCE.md` for an example.
+A convenient way to specify targets for the `ca_extend::upload_ca_cert` plan is by connecting Bolt to [PuppetDB](https://puppet.com/docs/bolt/latest/bolt_connect_puppetdb.html), after which [--query](https://puppet.com/docs/bolt/latest/bolt_command_reference.html#command-options) can be used to specify targets.
+See `REFERENCE.md` for an example.
 
-### Examples
+#### PCP
 
-```
+Note that you cannot use the Bolt `pcp` transport if your CA certificate has already expired, as the PXP-Agent service itself depends upon a valid CA certificate.
+
+### Usage
+
+```bash
 bolt plan run ca_extend::extend_ca_cert master=<master_fqdn> compile_masters=<comma_separated_compile_master_fqdns>
 ```
+
+Note that if you are running the `extend_ca_cert` on the Master, you can avoid potential Bolt transport issues by specifying `master=localhost`. 
+
+(The `master` and (optional) `compile_masters` parameters are Bolt targets, not certificate data.)
+
+```bash
+bolt plan run ca_extend::upload_ca_cert cert=<path_to_cert> --targets <TargetSpec>
 ```
-bolt plan run ca_extend::upload_ca_cert cert=<path_to_cert> --nodes <TargetSpec>
+
+```bash
+bolt task run ca_extend::check_ca_expiry --targets <TargetSpec>
 ```
+
+```bash
+bolt task run ca_extend::check_agent_expiry --targets <TargetSpec>
 ```
-bolt task run ca_extend::check_ca_expiry --nodes <TargetSpec>
-```
-```
-bolt task run ca_extend::check_agent_expiry --nodes <TargetSpec>
-```
-See `REFERENCE.md` for more detailed example commands
+
+See `REFERENCE.md` for more detailed examples.
+
+## Reference
+
+Puppet's security is based on a PKI using X.509 certificates.
+
+This module's `ca_extend::extend_ca_cert` plan creates a new self-signed CA certificate using the same keypair as the prior self-signed CA. The new CA has the same:
+
+* Keypair.
+* Subject.
+* Issuer.
+* X509v3 Subject Key Identifier (the fingerprint of the public key).
+
+The new CA has a different:
+
+* Authority Key Identifier (just the serial number, since it's self-signed).
+* Validity period (the point of the whole exercise).
+* Signature (since we changed the serial number and validity period).
+
+Since Puppet's services (and other services that use Puppet's PKI) validate certificates by trusting a self-signed CA and comparing its public key to the Signatures and Authority Key Identifiers of the certificates it has issued,
+it's possible to issue a new self-signed CA certificate based on a prior keypair without invalidating any certificates issued by the old CA.
+Once you've done that, it's just a matter of delivering the new CA certificate to every participant in the PKI.
+
+## Development
+
+Puppet Labs modules on the Puppet Forge are open source projects, and community contributions are essential for keeping them great.
+We can’t access the huge number of platforms and myriad of hardware, software, and deployment configurations that Puppet is intended to serve.
+We want to keep it as easy as possible to contribute changes so that our modules work in your environment.
+There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things.
+
+For more information, see our [module contribution guide.](https://docs.puppetlabs.com/forge/contributing.html)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 This module can extend a certificate authority (CA) that's about to expire or has already expired.
 
-A Puppet CA certificate is only valid for a finite time (usually five years), after which it expires.
+A Puppet CA certificate is only valid for a finite time (a new installation of PE 2019.x / Puppet 6.x will create a 15 year CA, while earlier versions will create a 5 year CA; and upgrading does not extend the CA.), after which it expires.
 When a CA certificate expires, Puppet services will no longer accept any certificates signed by that CA, and your Puppet infrastructure will immediately stop working.
 
 If your CA certificate is expiring soon (or it's already expired), you need to:

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -153,26 +153,27 @@ $ bolt plan run ca_extend::extend_ca_cert master=pe-master.example.com compile_m
 Starting: plan ca_extend::extend_ca_cert
 Starting: command 'echo "test" | base64 -w 0 - &>/dev/null' on localhost
 Finished: command 'echo "test" | base64 -w 0 - &>/dev/null' with 0 failures in 0.0 sec
-INFO: Stopping puppet and pe-puppetserver services on pe-master.example.com
+INFO: Stopping puppet services on pe-master.example.com
 Starting: task service on pe-master.example.com
 Finished: task service with 0 failures in 0.85 sec
 Starting: task service on pe-master.example.com
 Finished: task service with 0 failures in 1.95 sec
-INFO: Extending certificate on master pe-master.example.com
+INFO: Extending CA certificate on pe-master.example.com
 Starting: task ca_extend::extend_ca_cert on pe-master.example.com
 Finished: task ca_extend::extend_ca_cert with 0 failures in 2.92 sec
-INFO: Configuring master pe-master.example.com to use new certificate
+INFO: Configuring pe-master.example.com to use the extended CA certificate
 Starting: task ca_extend::configure_master on pe-master.example.com
 Finished: task ca_extend::configure_master with 0 failures in 95.72 sec
 Starting: task service on pe-master.example.com
 Finished: task service with 0 failures in 1.64 sec
-INFO: Configuring compile master(s) pe-compiler.example.com to use new certificate
+INFO: Stopping puppet services on compilers (pe-compiler.example.com)
+INFO: Configuring compilers (pe-compiler.example.com) to use the extended CA certificate
 Starting: file upload from /tmp/ca.pem to /etc/puppetlabs/puppet/ssl/certs/ca.pem on pe-compiler.example.com
 Finished: file upload from /tmp/ca.pem to /etc/puppetlabs/puppet/ssl/certs/ca.pem with 0 failures in 0.59 sec
 Starting: task run_agent on pe-compiler.example.com
 Finished: task run_agent with 0 failures in 44.34 sec
-INFO: CA cert decoded and stored at /tmp/ca.pem
-INFO: Run plan 'ca_extend::upload_ca_cert' to distribute to agents
+INFO: Extended CA certificate decoded and stored at /tmp/ca.pem
+INFO: Run the 'ca_extend::upload_ca_cert' plan to distribute the extended CA certificate to agents
 Finished: plan ca_extend::extend_ca_cert in 148.06 sec
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -238,7 +238,7 @@ Finished: plan ca_extend::upload_ca_cert in 17.41 sec
 
 #### Arguments
 
-* cert - Optional location of CA certificate on disk to check.  Defaults to ``/etc/puppetlabs/puppet/ssl/certs/ca.pem`.
+* cert - Optional location of CA certificate on disk to check. Defaults to `/etc/puppetlabs/puppet/ssl/certs/ca.pem`.
 * date - Optional YYYY-MM-DD format date against which to check for expiration. Defaults to three months from today.
 
 This task accepts any valid TargetSpec(s) specified by the `--targets` option.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -4,7 +4,9 @@
 
 ### ssh
 
-By default, Bolt will assume the `ssh` transport and use `~/.ssh.config` for configuration options.  Below is a sample `config` file and command.
+Bolt defaults to using the `ssh` transport, which will in turn use `~/.ssh/config` for options such as `username` and `private-key`.
+
+Below is a sample `config` file and command.
 
 ```
 Host pe-*
@@ -16,12 +18,12 @@ Host pe-*
   LogLevel ERROR
 ```
 
-```
-$ bolt plan run ca_extend::upload_ca_cert cert=/tmp/tmp.CuWtz3dmfx --run-as root --nodes pe-201815-agent
+```bash
+$ bolt plan run ca_extend::upload_ca_cert cert=/tmp/ca.pem --run-as root --targets pe-agent.example.com
 {
   "success": {
-    "pe-201815-agent": {
-      "_output": "Uploaded '/tmp/tmp.CuWtz3dmfx' to 'pe-201815-agent:/etc/puppetlabs/puppet/ssl/certs/ca.pem'"
+    "pe-agent.example.com": {
+      "_output": "Uploaded '/tmp/ca.pem' to 'pe-agent.example.com:/etc/puppetlabs/puppet/ssl/certs/ca.pem'"
     }
   }
 }
@@ -29,15 +31,17 @@ $ bolt plan run ca_extend::upload_ca_cert cert=/tmp/tmp.CuWtz3dmfx --run-as root
 
 ### Inventory
 
-See the [Bolt inventory](https://puppet.com/docs/bolt/latest/inventory_file.html) documentation for a full reference on how to use the inventory.  Below is a sample inventory created using [bolt-inventory-pdb](https://puppet.com/docs/bolt/latest/inventory_file_generating.html) and example commands.
+See the Bolt [inventory file](https://puppet.com/docs/bolt/latest/inventory_file.html) documentation for a full reference.
 
-```
+Below is a sample inventory created using [bolt-inventory-pdb](https://puppet.com/docs/bolt/latest/inventory_file_generating.html) and example commands.
+
+```bash
 $ cat pdb.yaml
 ---
 query: "inventory[certname] {}"
 groups:
 - name: windows
-  query: "inventory[certname] { facts.osfamily = 'windows' }"
+  query: "inventory[certname] { facts.os.family = 'windows' }"
   config:
     transport: winrm
     winrm:
@@ -54,17 +58,17 @@ groups:
       host-key-check: false
 ```
 
-```
+```bash
 $ /opt/puppetlabs/bolt/bin/bolt-inventory-pdb pdb.yaml -o ~/.puppetlabs/bolt/inventory.yaml
 ```
 
-```
+```bash
 $ cat ~/.puppetlabs/bolt/inventory.yaml
 ---
 query: inventory[certname] {}
 groups:
 - name: windows
-  query: inventory[certname] { facts.osfamily = 'windows' }
+  query: inventory[certname] { facts.os.family = 'windows' }
   config:
     transport: winrm
     winrm:
@@ -72,7 +76,7 @@ groups:
       password: foo
       ssl: false
   nodes:
-  - ljbkgu9t2x3ohqd.delivery.puppetlabs.net
+  - pe-agent-windows.example.com
 - name: linux
   query: inventory[certname] { facts.kernel = 'Linux' }
   config:
@@ -82,41 +86,41 @@ groups:
       private-key: "~/.ssh/id_rsa-acceptance"
       host-key-check: false
   nodes:
-  - pe-201815-master.puppetdebug.vlan
-  - pe-201815-agent.platform9.puppet.net
-  - pe-201815-compile.platform9.puppet.net
+  - pe-master.example.com
+  - pe-agent.example.com
+  - pe-compiler.example.com
 nodes:
-- ljbkgu9t2x3ohqd.delivery.puppetlabs.net
-- pe-201815-master.puppetdebug.vlan
-- pe-201815-agent.platform9.puppet.net
-- pe-201815-compile.platform9.puppet.net
+- pe-master.example.com
+- pe-compiler.example.com
+- pe-agent.example.com
+- pe-agent-windows.example.com
 ```
 
-```
-$ bolt command run hostname --nodes linux
-Started on pe-201815-compile.platform9.puppet.net...
-Started on pe-201815-master.puppetdebug.vlan...
-Started on pe-201815-agent.platform9.puppet.net...
-Finished on pe-201815-master.puppetdebug.vlan:
+```bash
+$ bolt command run hostname --targets linux
+Started on pe-master.example.com...
+Started on pe-compiler.example.com...
+Started on pe-agent.example.com...
+Finished on pe-master.example.com:
   STDOUT:
-    pe-201815-master.puppetdebug.vlan
-Finished on pe-201815-compile.platform9.puppet.net:
+    pe-master.example.com
+Finished on pe-compiler.example.com:
   STDOUT:
-    pe-201815-compile
-Finished on pe-201815-agent.platform9.puppet.net:
+    pe-compile.example.com
+Finished on pe-agent.example.com:
   STDOUT:
-    pe-201815-agent
-Successful on 3 nodes: pe-201815-master.puppetdebug.vlan,pe-201815-agent.platform9.puppet.net,pe-201815-compile.platform9.puppet.net
+    pe-agent.example.com
+Successful on 3 nodes: pe-master.example.com,pe-agent.example.com,pe-compiler.example.com
 Ran on 3 nodes in 0.62 seconds
 ```
 
-```
-$ bolt command run hostname --nodes windows
-Started on ljbkgu9t2x3ohqd.delivery.puppetlabs.net...
-Finished on ljbkgu9t2x3ohqd.delivery.puppetlabs.net:
+```bash
+$ bolt command run hostname --targets windows
+Started on pe-agent-windows.example.com...
+Finished on pe-agent-windows.example.com:
   STDOUT:
-    ljbkgu9t2x3ohqd
-Successful on 1 node: ljbkgu9t2x3ohqd.delivery.puppetlabs.net
+    pe-agent-windows.example.com
+Successful on 1 node: pe-agent-windows.example.com
 Ran on 1 node in 0.70 seconds
 ```
 
@@ -126,47 +130,48 @@ Ran on 1 node in 0.70 seconds
 
 #### Arguments
 
-* master - Fully qualified domain name of the master containing the certificate authority
-* compile_masters - Comma separated list of fully qualified domain names of compile masters
+* master - Fully-qualified domain name of the Master acting as the Certificate Authority
+* compile_masters - Optional comma-separated list of fully-qualified domain names of Compilers
 
 #### Steps
 
-* Runs the `service` task to stop the `puppet` and `pe-puppetserver` services on the master
-* Runs the `ca_extend::extend_ca_cert` task to dump the new cert to a file and return the path to the file and a base64 encoded string of its contents
-* Runs the `ca_extend::configure_master` task to backup the `ssl` directory to `/var/puppetlabs/backups`, copy the new cert into place, and configure the master to use the new cert
-* Decodes the cert's contents and dump it to a temp file
-* Uploads the new cert to any compile masters and configures them to use the new cert
+* Runs the `service` task to stop the `puppet` and `pe-puppetserver` services on the (Primary) Master
+* Runs the `ca_extend::extend_ca_cert` task to output the new CA certificate to a file, and return the path to the file and a base64 encoded string of its contents
+* Runs the `ca_extend::configure_master` task to backup the `ssl` directory to `/var/puppetlabs/backups`, copy the new CA certificate in-place, and configure the Master to use that certificate
+* Decodes the CA certificate's contents and outputs it to a temp file
+* Uploads the new CA certificate to any Compilers and configures them to use that certificate
 
 #### Output
 
-All steps in this plan are critical to extending the certificate, so the plan will fail if any step fails.  The output consists of Bolt logging messages and any failures of the steps involved.
+All of the steps in this plan are critical to extending the certificate, so the plan will fail if any step fails.
+The output consists of Bolt logging messages and any failures of the steps involved.
 
 ### Example
 
-```
-$ bolt plan run ca_extend::extend_ca_cert master=pe-201815-master compile_masters=pe-201815-compile --run-as root
+```bash
+$ bolt plan run ca_extend::extend_ca_cert master=pe-master.example.com compile_masters=pe-compiler.example.com --run-as root
 Starting: plan ca_extend::extend_ca_cert
 Starting: command 'echo "test" | base64 -w 0 - &>/dev/null' on localhost
 Finished: command 'echo "test" | base64 -w 0 - &>/dev/null' with 0 failures in 0.0 sec
-INFO: Stopping puppet and pe-puppetserver services on pe-201815-master
-Starting: task service on pe-201815-master
+INFO: Stopping puppet and pe-puppetserver services on pe-master.example.com
+Starting: task service on pe-master.example.com
 Finished: task service with 0 failures in 0.85 sec
-Starting: task service on pe-201815-master
+Starting: task service on pe-master.example.com
 Finished: task service with 0 failures in 1.95 sec
-INFO: Extending certificate on master pe-201815-master
-Starting: task ca_extend::extend_ca_cert on pe-201815-master
+INFO: Extending certificate on master pe-master.example.com
+Starting: task ca_extend::extend_ca_cert on pe-master.example.com
 Finished: task ca_extend::extend_ca_cert with 0 failures in 2.92 sec
-INFO: Configuring master pe-201815-master to use new certificate
-Starting: task ca_extend::configure_master on pe-201815-master
+INFO: Configuring master pe-master.example.com to use new certificate
+Starting: task ca_extend::configure_master on pe-master.example.com
 Finished: task ca_extend::configure_master with 0 failures in 95.72 sec
-Starting: task service on pe-201815-master
+Starting: task service on pe-master.example.com
 Finished: task service with 0 failures in 1.64 sec
-INFO: Configuring compile master(s) pe-201815-compile to use new certificate
-Starting: file upload from /tmp/tmp.CuWtz3dmfx to /etc/puppetlabs/puppet/ssl/certs/ca.pem on pe-201815-compile
-Finished: file upload from /tmp/tmp.CuWtz3dmfx to /etc/puppetlabs/puppet/ssl/certs/ca.pem with 0 failures in 0.59 sec
-Starting: task run_agent on pe-201815-compile
+INFO: Configuring compile master(s) pe-compiler.example.com to use new certificate
+Starting: file upload from /tmp/ca.pem to /etc/puppetlabs/puppet/ssl/certs/ca.pem on pe-compiler.example.com
+Finished: file upload from /tmp/ca.pem to /etc/puppetlabs/puppet/ssl/certs/ca.pem with 0 failures in 0.59 sec
+Starting: task run_agent on pe-compiler.example.com
 Finished: task run_agent with 0 failures in 44.34 sec
-INFO: CA cert decoded and stored at /tmp/tmp.CuWtz3dmfx
+INFO: CA cert decoded and stored at /tmp/ca.pem
 INFO: Run plan 'ca_extend::upload_ca_cert' to distribute to agents
 Finished: plan ca_extend::extend_ca_cert in 148.06 sec
 ```
@@ -175,49 +180,52 @@ Finished: plan ca_extend::extend_ca_cert in 148.06 sec
 
 #### Arguments
 
-*  cert - Location of the new certificate on disk.
+*  cert - Location of the new CA certificate on disk.
 
-This plan accepts any valid TargetSpec(s) specified by the `--nodes` option.
+This plan accepts any valid TargetSpec(s) specified by the `--targets` option.
 
 #### Steps
 
 * Collects facts from agents and separates them into groups of \*nix and Windows
-* Runs `upload_file` on each list of agents to distribute the cert
+* Runs `upload_file` on each list of agents to distribute the CA certificate
 * Constructs a JSON formatted object of the results of the uploads and returns it
 
 #### Output
 
-The output of this plan is a JSON object with two keys: `success` and `failure`.  Each key contains any number of objects consisting of the agent certname and the output of the `upload_file` command.
+The output of this plan is a JSON object with two keys: `success` and `failure`. 
+Each key contains any number of objects consisting of the agent certname and the output of the `upload_file` command.
 
-```
-$ bolt plan run ca_extend::upload_ca_cert cert=/tmp/tmp.CuWtz3dmfx --run-as root --query 'inventory { }'
+### Example
+
+```bash
+$ bolt plan run ca_extend::upload_ca_cert cert=/tmp/ca.pem --run-as root --query 'inventory { }'
 Starting: plan ca_extend::upload_ca_cert
 Starting: plan ca_extend::get_agent_facts
-Starting: install puppet and gather facts on pe-201815-agent.platform9.puppet.net, ljbkgu9t2x3ohqd.delivery.puppetlabs.net, pe-201815-master.puppetdebug.vlan, pe-201815-compile.platform9.puppet.net
+Starting: install puppet and gather facts on pe-master.example.com, pe-compiler.example.com, pe-agent.example.com, pe-agent-windows.example.com
 Finished: install puppet and gather facts with 0 failures in 9.33 sec
 Finished: plan ca_extend::get_agent_facts in 9.33 sec
 Starting: plan facts
-Starting: task facts on pe-201815-agent.platform9.puppet.net, ljbkgu9t2x3ohqd.delivery.puppetlabs.net, pe-201815-master.puppetdebug.vlan, pe-201815-compile.platform9.puppet.net
+Starting: task facts on pe-master.example.com, pe-compiler.example.com, pe-agent.example.com, pe-agent-windows.example.com
 Finished: task facts with 0 failures in 6.27 sec
 Finished: plan facts in 6.31 sec
-Starting: file upload from /tmp/tmp.CuWtz3dmfx to C:\ProgramData\PuppetLabs\puppet\etc\ssl\certs\ca.pem on ljbkgu9t2x3ohqd.delivery.puppetlabs.net
-Finished: file upload from /tmp/tmp.CuWtz3dmfx to C:\ProgramData\PuppetLabs\puppet\etc\ssl\certs\ca.pem with 0 failures in 1.07 sec
-Starting: file upload from /tmp/tmp.CuWtz3dmfx to /etc/puppetlabs/puppet/ssl/certs/ca.pem on pe-201815-agent.platform9.puppet.net, pe-201815-master.puppetdebug.vlan, pe-201815-compile.platform9.puppet.net
-Finished: file upload from /tmp/tmp.CuWtz3dmfx to /etc/puppetlabs/puppet/ssl/certs/ca.pem with 0 failures in 0.66 sec
+Starting: file upload from /tmp/ca.pem to /etc/puppetlabs/puppet/ssl/certs/ca.pem on pe-master.example.com, pe-compiler.example.com, pe-agent.example.com
+Finished: file upload from /tmp/ca.pem to /etc/puppetlabs/puppet/ssl/certs/ca.pem with 0 failures in 0.66 sec
+Starting: file upload from /tmp/ca.pem to C:\ProgramData\PuppetLabs\puppet\etc\ssl\certs\ca.pem on pe-agent-windows.example.com
+Finished: file upload from /tmp/ca.pem to C:\ProgramData\PuppetLabs\puppet\etc\ssl\certs\ca.pem with 0 failures in 1.07 sec
 Finished: plan ca_extend::upload_ca_cert in 17.41 sec
 {
   "success": {
-    "pe-201815-agent.platform9.puppet.net": {
-      "_output": "Uploaded '/tmp/tmp.CuWtz3dmfx' to 'pe-201815-agent.platform9.puppet.net:/etc/puppetlabs/puppet/ssl/certs/ca.pem'"
+    "pe-master.example.com": {
+      "_output": "Uploaded '/tmp/ca.pem' to 'pe-master.example.com:/etc/puppetlabs/puppet/ssl/certs/ca.pem'"
     },
-    "pe-201815-master.puppetdebug.vlan": {
-      "_output": "Uploaded '/tmp/tmp.CuWtz3dmfx' to 'pe-201815-master.puppetdebug.vlan:/etc/puppetlabs/puppet/ssl/certs/ca.pem'"
+    "pe-compiler.example.com": {
+      "_output": "Uploaded '/tmp/ca.pem' to 'pe-compiler.example.com:/etc/puppetlabs/puppet/ssl/certs/ca.pem'"
     },
-    "pe-201815-compile.platform9.puppet.net": {
-      "_output": "Uploaded '/tmp/tmp.CuWtz3dmfx' to 'pe-201815-compile.platform9.puppet.net:/etc/puppetlabs/puppet/ssl/certs/ca.pem'"
+    "pe-agent.example.com": {
+      "_output": "Uploaded '/tmp/ca.pem' to 'pe-agent.example.com:/etc/puppetlabs/puppet/ssl/certs/ca.pem'"
     },
-    "ljbkgu9t2x3ohqd.delivery.puppetlabs.net": {
-      "_output": "Uploaded '/tmp/tmp.CuWtz3dmfx' to 'ljbkgu9t2x3ohqd.delivery.puppetlabs.net:C:\\ProgramData\\PuppetLabs\\puppet\\etc\\ssl\\certs\\ca.pem'"
+    "pe-agent-windows.example.com": {
+      "_output": "Uploaded '/tmp/ca.pem' to 'pe-agent-windows.example.com:C:\\ProgramData\\PuppetLabs\\puppet\\etc\\ssl\\certs\\ca.pem'"
     }
   }
 }
@@ -229,20 +237,23 @@ Finished: plan ca_extend::upload_ca_cert in 17.41 sec
 
 #### Arguments
 
-* cert - Optional location of certificate on disk to check.  Defaults to /etc/puppetlabs/puppet/ssl/certs/ca.pem.
-* date - Optional YYYY-MM-DD format date against which to check for expiration. Defaults to 3 months in the future.
+* cert - Optional location of CA certificate on disk to check.  Defaults to ``/etc/puppetlabs/puppet/ssl/certs/ca.pem`.
+* date - Optional YYYY-MM-DD format date against which to check for expiration. Defaults to three months from today.
 
-This task accepts any valid TargetSpec(s) specified by the `--nodes` option. Can be run on any \*nix agent node or the master.
+This task accepts any valid TargetSpec(s) specified by the `--targets` option.
+Can be run on any \*nix agent node or the Master.
 
 #### Steps
 
-* Uses `openssl` and Unix `date` to determine if the certificate will expire.
+* Uses Unix `openssl` and `date` to determine if the CA certificate will expire.
 
 #### Output
 
-A JSON object with the status and expiration date, e.g.
+A JSON object with the status and expiration date of the CA certificate.
 
-```
+### Example
+
+```bash
 {
   "status": "valid",
   "expiry date": "Feb 16 01:00:09 2034 GMT"
@@ -253,30 +264,29 @@ A JSON object with the status and expiration date, e.g.
 
 #### Arguments
 
-* date - Optional YYYY-MM-DD format date against which to check for expiration
+* date - Optional YYYY-MM-DD format date against which to check for expiration. Defaults to three months from today.
 
-This task accepts any valid TargetSpec(s) specified by the `--nodes` option. Should be run on the master.
+This task accepts any valid TargetSpec(s) specified by the `--targets` option.
+Should be run on the Master.
 
 #### Steps
 
-* Uses `openssl` and Unix `date` to determine if the signed agent certificates under `/etc/puppetlabs/puppet/ssl/ca/signed/` will expire.
+* Uses Unix `openssl` and `date` to determine if the agent certificates in `/etc/puppetlabs/puppet/ssl/ca/signed/` will expire.
 
 #### Output
 
-A JSON object with keys for valid and expiring certificates, e.g.
+A JSON object with keys for valid and expiring certificates.
 
-```
+### Example
+
+```bash
   {
     "valid": [
-      "/etc/puppetlabs/puppet/ssl/ca/signed/c4lscpmafhaxjr8.delivery.puppetlabs.net.pem",
-      "/etc/puppetlabs/puppet/ssl/ca/signed/cd4pe-containers.platform9.puppet.net.pem",
-      "/etc/puppetlabs/puppet/ssl/ca/signed/iwj6668y4s3vq40.delivery.puppetlabs.net.pem",
-      "/etc/puppetlabs/puppet/ssl/ca/signed/koo1nzsozj2xeqh.delivery.puppetlabs.net.pem",
-      "/etc/puppetlabs/puppet/ssl/ca/signed/mafy3pgo98v2vne.delivery.puppetlabs.net.pem",
-      "/etc/puppetlabs/puppet/ssl/ca/signed/pe-201901-agent.platform9.puppet.net.pem",
-      "/etc/puppetlabs/puppet/ssl/ca/signed/pe-201901-compile.puppetdebug.vlan.pem",
-      "/etc/puppetlabs/puppet/ssl/ca/signed/pe-201901-master.puppetdebug.vlan.pem",
-      "/etc/puppetlabs/puppet/ssl/ca/signed/qgocotu07r3rdpa.delivery.puppetlabs.net.pem"
+      "/etc/puppetlabs/puppet/ssl/ca/signed/pe-master.example.com.pem",
+      "/etc/puppetlabs/puppet/ssl/ca/signed/pe-compiler.example.com.pem",
+      "/etc/puppetlabs/puppet/ssl/ca/signed/pe-agent.example.com.pem",
+      "/etc/puppetlabs/puppet/ssl/ca/signed/pe-agent.example.com",
+      "/etc/puppetlabs/puppet/ssl/ca/signed/pe-agent-windows.example.com.pem",
     ],
     "expiring": [
 

--- a/files/extend.sh
+++ b/files/extend.sh
@@ -80,5 +80,5 @@ yes | "${PUPPET_BIN}/openssl" ca \
   -enddate "${end_date}" \
   -out "${new_ca_cert}" >&2
 
-printf '\nRenewed CA certificate created\n' >&2
+printf '\nRenewed CA certificate\n' >&2
 printf '%s\n' "${new_ca_cert}"

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.2.0 < 6.0.0"
+      "version_requirement": ">= 4.10.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/plans/get_agent_facts.pp
+++ b/plans/get_agent_facts.pp
@@ -1,5 +1,6 @@
-# This plan is to work around BOLT-1168 so that one agent failing in
-# apply_prep won't cause the whole plan to fail
+# This plan is to work around BOLT-1168,
+# so that one agent failing in apply_prep won't cause the whole plan to fail.
+
 plan ca_extend::get_agent_facts(TargetSpec $nodes) {
   $nodes.apply_prep
 }

--- a/plans/upload_ca_cert.pp
+++ b/plans/upload_ca_cert.pp
@@ -1,4 +1,7 @@
-plan ca_extend::upload_ca_cert(TargetSpec $nodes, String $cert) {
+plan ca_extend::upload_ca_cert(
+  TargetSpec $nodes,
+  String     $cert
+) {
   # Work around BOLT-1168
   run_plan('ca_extend::get_agent_facts', 'nodes' => $nodes, '_catch_errors' => true)
   $tmp = run_plan('facts', 'targets' => $nodes, '_catch_errors' => true)
@@ -15,7 +18,7 @@ plan ca_extend::upload_ca_cert(TargetSpec $nodes, String $cert) {
     }
   }
 
-  # os.family should consistantly be "windows" on, well, Windows
+  # The os.family fact should consistantly be "windows" on, well, Windows.
   $windows_targets = $results.ok_set.filter |$n| { "${n.value['os']['family']}" == 'windows' }
   $linux_targets = $results.ok_set.filter |$n| { ! ("${n.value['os']['family']}" == 'windows') }
 

--- a/tasks/check_agent_expiry.json
+++ b/tasks/check_agent_expiry.json
@@ -1,8 +1,8 @@
 {
-  "description": "Check the expiration date of all agents",
+  "description": "Check the expiration date of all agent certificates",
   "parameters": {
     "date": {
-      "description": "YYYY-MM-DD date to test whether the cert will expire by. Defaults to three months from today",
+      "description": "YYYY-MM-DD date to test whether the certificates will expire by. Defaults to three months from today",
       "type": "Optional[String[1]]"
     }
   },

--- a/tasks/check_agent_expiry.sh
+++ b/tasks/check_agent_expiry.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 declare PT__installdir
 source "$PT__installdir/ca_extend/files/common.sh"
 PUPPET_BIN='/opt/puppetlabs/puppet/bin'
@@ -7,11 +8,11 @@ valid=()
 expired=()
 
 to_date="${date:-+3 months}"
-to_date="$(date --date="$to_date" +"%s")" || fail "Error calculating expiry date"
+to_date="$(date --date="$to_date" +"%s")" || fail "Error calculating date"
 
 shopt -s nullglob
 for f in /etc/puppetlabs/puppet/ssl/ca/signed/*; do
-  # it's possible that we are not on a Puppet AIO system. If we cannot find a
+  # It's possible that we are not on a Puppet AIO system. If we cannot find a
   # openssl binary in the AIO directory, we accept one in $PATH
   if [ "$(command -v "${PUPPET_BIN}/openssl")" ]; then
     openssl="${PUPPET_BIN}/openssl"
@@ -23,7 +24,7 @@ for f in /etc/puppetlabs/puppet/ssl/ca/signed/*; do
   # So, we'll use bash arithmetic and `date` to do the comparison
   expiry_date="$(${openssl} x509 -enddate -noout -in "${f}")"
   expiry_date="${expiry_date#*=}"
-  expiry_seconds="$(date --date="$expiry_date" +"%s")" || fail "Error calculating expiry date"
+  expiry_seconds="$(date --date="$expiry_date" +"%s")" || fail "Error calculating expiry date from enddate"
 
   if (( $to_date >= $expiry_seconds )); then
     expired+=("\"$f\"")

--- a/tasks/check_ca_expiry.json
+++ b/tasks/check_ca_expiry.json
@@ -2,11 +2,11 @@
   "description": "Check the expiration date of a CA certificate",
   "parameters": {
     "cert": {
-      "description": "Location of the cert to check.  Defaults to the standard Puppet ca.pem location",
+      "description": "Location of the CA certificate to check. Defaults to Puppet's default location",
       "type": "Optional[String[1]]"
     },
     "date": {
-      "description": "YYYY-MM-DD date to test whether the cert will expire by. Defaults to three months from today",
+      "description": "YYYY-MM-DD date to test whether the certificate will expire by. Defaults to three months from today",
       "type": "Optional[String[1]]"
     }
   },

--- a/tasks/check_ca_expiry.sh
+++ b/tasks/check_ca_expiry.sh
@@ -1,23 +1,24 @@
 #!/bin/bash
+
 declare PT__installdir
 source "$PT__installdir/ca_extend/files/common.sh"
+PUPPET_BIN='/opt/puppetlabs/puppet/bin'
 
 cert="${cert:-/etc/puppetlabs/puppet/ssl/certs/ca.pem}"
 [[ -e $cert ]] || fail "cert $cert not found"
 
 to_date="${date:-+3 months}"
-to_date="$(date --date="$to_date" +"%s")" || fail "Error calculating expiry date"
+to_date="$(date --date="$to_date" +"%s")" || fail "Error calculating date"
 
 # Sanity check that we're dealing with a valid cert
-PUPPET_BIN='/opt/puppetlabs/puppet/bin'
-"${PUPPET_BIN}/openssl" x509 -in "$cert" >/dev/null || fail "error checking $cert"
+"${PUPPET_BIN}/openssl" x509 -in "$cert" >/dev/null || fail "Error checking $cert"
 
 # The -checkend command in openssl takes a number of seconds as an argument
 # However, on older versions we may overflow a 32 bit integer if we use that
 # So, we'll use bash arithmetic and `date` to do the comparison
 expiry_date="$("${PUPPET_BIN}/openssl" x509 -enddate -noout -in /etc/puppetlabs/puppet/ssl/certs/ca.pem)"
 expiry_date="${expiry_date#*=}"
-expiry_seconds="$(date --date="$expiry_date" +"%s")" || fail "Error calculating expiry date"
+expiry_seconds="$(date --date="$expiry_date" +"%s")" || fail "Error calculating expiry date from enddate"
 
 if (( $to_date >= $expiry_seconds )); then
   success "{ \"status\": \"will expire\", \"expiry date\": \"$expiry_date\" }"

--- a/tasks/configure_master.json
+++ b/tasks/configure_master.json
@@ -1,8 +1,8 @@
 {
-  "description": "Backup ssldir and move new CA cert",
+  "description": "Backup ssldir and copy newly generated CA certificate",
   "parameters": {
     "new_cert": {
-      "description": "Location of the newly generated CA cert",
+      "description": "Location of the newly generated CA certificate",
       "type": "String"
     }
   },

--- a/tasks/configure_master.sh
+++ b/tasks/configure_master.sh
@@ -3,11 +3,11 @@
 declare PT__installdir
 source "$PT__installdir/ca_extend/files/common.sh"
 
-\cp -R /etc/puppetlabs/puppet/ssl /var/puppetlabs/backups || fail "Error backing up ssl dir"
+\cp -R /etc/puppetlabs/puppet/ssl /var/puppetlabs/backups || fail "Error backing up '/etc/puppetlabs/puppet/ssl'"
 
-\cp "$new_cert" /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem || fail "Error copying cert"
-\cp "$new_cert" /etc/puppetlabs/puppet/ssl/certs/ca.pem || fail "Error copying cert"
+\cp "$new_cert" /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem || fail "Error copying 'ca_crt.pem'"
+\cp "$new_cert" /etc/puppetlabs/puppet/ssl/certs/ca.pem || fail "Error copying 'ca.pem"
 
-PATH="${PATH}:/opt/puppetlabs/bin" puppet infrastructure configure --no-recover || fail "Error configuring infrastructure"
+PATH="${PATH}:/opt/puppetlabs/bin" puppet infrastructure configure --no-recover || fail "Error running 'puppet infrastructure configure'"
 
 success '{ "status": "success" }'

--- a/tasks/extend_ca_cert.json
+++ b/tasks/extend_ca_cert.json
@@ -1,5 +1,5 @@
 {
-  "description": "Get the platform release of a node",
+  "description": "Extend CA certificate expiry date",
   "implementations": [
     {"name": "extend_ca_cert.sh", "requirements": ["shell"], "files": ["ca_extend/files/common.sh", "ca_extend/files/extend.sh"], "input_method": "environment"}
   ]

--- a/tasks/extend_ca_cert.sh
+++ b/tasks/extend_ca_cert.sh
@@ -3,9 +3,9 @@
 declare PT__installdir
 source "$PT__installdir/ca_extend/files/common.sh"
 
-echo "test" | base64 -w 0 - &>/dev/null || fail "This utility requires a version of base64 with the -w flag"
+echo "test" | base64 -w 0 - &>/dev/null || fail "This script requires a version of base64 with the -w flag"
 
-new_cert="$(bash "$PT__installdir/ca_extend/files/extend.sh")" || fail "Error extending cert expiry date"
-contents="$(base64 -w 0 "$new_cert")" || fail "Error encoding cert"
+new_cert="$(bash "$PT__installdir/ca_extend/files/extend.sh")" || fail "Error extending CA certificate expiry date"
+contents="$(base64 -w 0 "$new_cert")" || fail "Error encoding CA certificate"
 
 success "{ \"status\": \"success\", \"new_cert\": \"$new_cert\", \"contents\": \"$contents\" }"


### PR DESCRIPTION
Extend stdlib dependency.
Add note for localhost transport.
Normalize language and examples.
Reuse documentantion from puppetlabs-certregen
