### PR TITLE
Use run_tasks for facts and catch errors.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-ca_extend",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "Adrian Parreiras Horta",
   "summary": "A set of Bolt Plans and Tasks to extend the CA cert in Puppet Enterprise",
   "license": "GPL-2.0-only",

--- a/plans/extend_ca_cert.pp
+++ b/plans/extend_ca_cert.pp
@@ -4,7 +4,7 @@ plan ca_extend::extend_ca_cert(
   $ssldir                               = '/etc/puppetlabs/puppet/ssl',
 ) {
   $targets.apply_prep
-  $master_facts = run_plan('facts', $targets).first
+  $master_facts = run_task('facts', $targets, '_catch_errors' => true).first
 
   if $master_facts['pe_build'] {
     $is_pe = true


### PR DESCRIPTION
Prior to this commit, using run_plan for facts and not catching errors
would fail the entire plan if an external fact failed.  By using
run_task and catching errors, we avoid this failure and get a ResultSet
object back regardless of the return code of the facts task.